### PR TITLE
Add Twilight Festival guide page

### DIFF
--- a/docs/Twilight_Festival.md
+++ b/docs/Twilight_Festival.md
@@ -1,0 +1,54 @@
+---
+hide:
+  - toc
+---
+
+# \U0001F306 Twilight Festival
+*July-August 2025*
+
+---
+
+## 1. Farm for Rental Access Gear
+Hunt mobs in caves and on beaches to collect materials for the **Rental Scuba Mask** and **Rental Oxygen Tank**.
+
+![Placeholder](img/10002.png)
+
+---
+
+## 2. Craft the Boxes
+Visit the **Box Crafter NPC** in the event area.
+**Items Needed:** 200× Cold Ice, 200× Light Granule.
+**Rewards:** Scuba Mask Box and Oxygen Tank Box.
+
+![Placeholder](img/10002.png)
+
+---
+
+## 3. Enter the Lasagna Dungeon
+**Requirements:** Equip both Rental Scuba Mask and Rental Oxygen Tank.
+**Cost:** 10,000 Zeny per warp.
+
+![Placeholder](img/10002.png)
+
+---
+
+## 4. Farm Tickets and Loot
+Defeat mobs in the Twilight Dungeon to collect tickets for event shops and the **Wheel of Fortune**.
+**No Penalties:** You won't lose experience if you die.
+
+![Placeholder](img/10002.png)
+
+---
+
+## 5. Spin the Wheel of Fortune
+Use special Festival Tickets dropped from mobs to spin the Wheel and earn exclusive items, pets, and costumes.
+
+![Placeholder](img/10002.png)
+
+---
+
+## 6. Visit Event Shops
+Exchange your tickets for powerful items and costumes. Multiple event shops are available in the event area.
+
+![Placeholder](img/10002.png)
+

--- a/docs/patches06252025.md
+++ b/docs/patches06252025.md
@@ -19,7 +19,7 @@ During this event, you'll gain access to a special map (**Lasagna Dungeon**) fil
 - **Kraken MVP** is available to hunt.
 
 !!! info "Event Duration"
-    The event runs until the end of summer. Wheel of Fortune prizes rotate with each maintenance. [Guide and item list](insert link).
+    The event runs until the end of summer. Wheel of Fortune prizes rotate with each maintenance. [Guide and item list](Twilight_Festival.md).
 
 ---
 


### PR DESCRIPTION
## Summary
- add new Twilight Festival guide page with event steps
- link the patch notes to the new guide

## Testing
- `mkdocs-venv/bin/python mkdocs-venv/bin/mkdocs build` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685c9656ff488322a57d43c34de2863a