### PR TITLE
Cleanup Markdown layout for 09/01/2025 patch notes

### DIFF
--- a/docs/patches09012025.md
+++ b/docs/patches09012025.md
@@ -6,18 +6,18 @@ title: "Patch Notes - 09/01/2025"
 
 ## General
 
-- **Client Proxies**  
-  Added built-in proxy tunnels for smoother gameplay outside the server’s region.  
+- **Client Proxies**
+  Added built-in proxy tunnels for smoother gameplay outside the server’s region.
+
   **Available locations:**
-  ```
-  - New York
-  - São Paulo
-  - Singapore (preferred for Asia players)
-  - Tokyo
-  - Sydney
-  ```
-  !!! note
-      Proxies will be tested during the month; locations/behavior may be adjusted based on performance.
+    - `New York`
+    - `São Paulo`
+    - `Singapore` (preferred for Asia players)
+    - `Tokyo`
+    - `Sydney`
+
+  > **Note**  
+  > Proxies will be tested during the month; locations/behavior may be adjusted based on performance.
 
 - **Gold Point System / Redemption Revamp**  
   Instead of exchanging for Gift/Blue Boxes, you now redeem **Virtual Points** for **Golden Coins**:
@@ -44,10 +44,12 @@ title: "Patch Notes - 09/01/2025"
 
 - **Barter NPC**: `Dusty Tomb Volumes → 20 × Temporal Crystals` each.
 - **Party Menu Buff Letters**: `B` = Blessing, `A` = Agi Up, `F` = FCP, `S` = Soul Link, `U` = Assumptio.
-  ![Party Buff](img/party-statuses.webp)
+  <img src="img/party-statuses.webp" alt="Party Buff" align="left" />
+
 - **Party Loot**: Added `Enriched Elu/Ori Box` to party member loot display message.
 - **Guarana Candy**: Bulk purchase up to `300` each from the quest NPC.
-- **Cursed Water**: Bulk conversion at **Niff Fountain**; choose `Singular` or `All` (based on empty bottles). Includes weight check.
+- **Cursed Water**: Bulk conversion at **Niff Fountain**; choose `Singular` or `All` (based on empty bottles). Includes
+  weight check.
 - **Drop Identifiers**: Added `Incubus` + `Succubus` egg identifiers to party drop messages.
 - **Guild MOTD Visibility**: Moved to bottom of login list for visibility.
 - **Minimap Recall**: Added “previous position” marker when using `Teleport`, `Fly Wing`, `Infinite Fly Wing`.  
@@ -58,19 +60,23 @@ title: "Patch Notes - 09/01/2025"
 
 ## Items
 
-- **Bag of Gold Coins**: Weight reduced `1500 → 500`.  
-  !!! note
-      Remains **untradeable** with **move restrictions** limited to **personal storage**.
+- **Bag of Gold Coins**: Weight reduced `1500 → 500`.
+
+  > **Note**  
+  > Remains **untradeable** with **move restrictions** limited to **personal storage**.
 
 - **Poring Coin**: No longer sellable to NPCs.
-- **Snake Hat [0]**: Added as a rare drop from **Evil Snake Lord** MVP at `0.9%`.  
-  !!! note
-      **Chick Hat** remains available as a quicker alternative via the **Dimonka Questable Headgear** in the **Main Office**.
+- **Snake Hat [0]**: Added as a rare drop from **Evil Snake Lord** MVP at `0.9%`.
+
+  > **Note**  
+  > **Chick Hat** remains available as a quicker alternative via the
+  > **Dimonka Questable Headgear** in the **Main Office**.
 
 - **Anubis Hat**: Now refinable.
 - **Wanderer’s Skull (taming item)**: Move restrictions lifted.
 - **Fallen Bishop**: Added **Crown of Deceit** to drop table; `INT` adjusted `4 → 3`.
-- **Event Costumes**: Added new event costumes and removed a few from the **Event Ticket** shop (Event Token NPC in Main Office).
+- **Event Costumes**: Added new event costumes and removed a few from the **Event Ticket** shop
+  (Event Token NPC in Main Office).
 - **OCA Pool Cleanup**: Removed blocked **Culvert** mob cards that do not exchange at the card NPC:
   - `Thief Bug`
   - `Male Thief Bug`
@@ -82,9 +88,10 @@ title: "Patch Notes - 09/01/2025"
 
 ## NPC
 
-- **New Hairstyles**: Released `42` styles for each gender.  
-  !!! warning
-      Styles `38–42` may only have default colors; additional colors are bugged and may not apply.
+- **New Hairstyles**: Released `42` styles for each gender.
+
+  > **Warning**  
+  > Styles `38–42` may only have default colors; additional colors are bugged and may not apply.
 
 - **Manual Exchange (100%) – Main Office**: Added `x1` exchanges for:
   - `Level 10 Blessing Scroll Box (10 scrolls)`
@@ -93,7 +100,7 @@ title: "Patch Notes - 09/01/2025"
 
 - **Expanded Tool Dealers**: Added `Meat`.
 - **Katryn (PC 500x Costumes, Main Office)**: Added `10` costumes.
-  ![New Costumes](img/new-costumes-pc3.webp)
+  <img src="img/new-costumes-pc3.webp" alt="New Costumes" align="left" />
 - **Inn Updates**:
   - Added **Inn** to **Eastern Izlude**.
   - Relocated **Payon Inn** NPC to a more convenient position.
@@ -135,7 +142,8 @@ title: "Patch Notes - 09/01/2025"
 - **Magnus Exorcismus**: Damage ticks correctly even when caster is `Stunned / Petrified / Frozen`.
 - **Sighttrasher**: Now checks for **obstructions** before applying damage.
 - **Stat/Skill Reset NPC Improvements**:
-  - First reset for **New and Existing** players is **server-wide (character-based)** for each of `Stat / Skill / Both`. Prices unchanged.
+  - First reset for **New and Existing** players is **server-wide (character-based)** for each of `Stat / Skill / Both`.
+    Prices unchanged.
   - Added **confirmation** prompts before reset.
 
 - **Preserve (Skill)**:
@@ -143,10 +151,12 @@ title: "Patch Notes - 09/01/2025"
   - **Persists** through logout.
   - Still **dispellable** unless **Soul Linked**.
 
-- **Super Novice – 3 Skills Added (Nerfed)**  
-  !!! note
-      The added “ATK” behaves like **Sword Mastery** (applied in damage formula) and **will not** appear on `ALT+A` Attack stat.
-  ![Super Novice Skills](img/sn-skill-list.webp)
+- **Super Novice – 3 Skills Added (Nerfed)**
+
+  > **Note**  
+  > The added “ATK” behaves like **Sword Mastery** (applied in damage formula) and **will not** appear on `ALT+A`
+  > Attack stat.
+  <img src="img/sn-skill-list.webp" alt="Super Novice Skills" align="left" />
 
 - **Gunslinger – Adjustment**:
   - `SP`: `15 → 10`
@@ -164,8 +174,9 @@ title: "Patch Notes - 09/01/2025"
 - **Gym Pass**: Enlarge Weight Limit has **no effect** in Pre-Trans WoE.  
   Merchant class still retains base skill behavior.
 - **Blocked Gear**: **Icepick** / **Combat Knife** and **enchants** are blocked **inside the castle**.
-  !!! important
-      These restrictions apply **inside the castle only**. Adjust `@restock` and manage weight **before** entering.
+
+  > **Important**  
+  > These restrictions apply **inside the castle only**. Adjust `@restock` and manage weight **before** entering.
 
 ---
 
@@ -227,22 +238,25 @@ Exceptions:
 
 ## Cash Shop
 
-- **Cart Sprites**: Added `5` new cart sprites unlockable via **Cash Shop Voucher** (tradeable; Merchant classes only).  
-  ![New Carts](img/cart-cash.webp)
+- **Cart Sprites**: Added `5` new cart sprites unlockable via **Cash Shop Voucher**
+  (tradeable; Merchant classes only).
 
-- **Costumes**: Small set of new costumes added.  
-  ![New Costumes](img/cash-shop-new-1.webp)
+  <img src="img/cart-cash.webp" alt="New Carts" align="left" />
+
+- **Costumes**: Small set of new costumes added.
+  <img src="img/cash-shop-new-1.webp" alt="New Costumes" align="left" />
 
 ---
 
 ## ❤️ Support the Server!
 
-![Support](img/writereviewover2.gif)
+<img src="img/writereviewover2.gif" alt="Support" align="left" />
 
-If you love the server, please consider **leaving a review on RMS**.  
+If you love the server, please consider **leaving a review on RMS**.
 Your feedback helps us grow and keeps the community thriving! 🚀
 
-👉 [**Rate Our Server on RMS**](https://ratemyserver.net/index.php?page=detailedlistserver&serid=22102&itv=6&url_sname=UARO%20World%20of%20your%20dream)
+👉 [**Rate Our Server on RMS**][rms-link]
 
+[rms-link]: https://ratemyserver.net/index.php?page=detailedlistserver&serid=22102&itv=6&url_sname=UARO%20World%20of%20your%20dream
 
 ---


### PR DESCRIPTION
## Summary
- convert code-blocked proxy list into nested bullets with note callout
- replace admonition syntax with Markdown blockquotes
- left-align images in QoL, NPC, Skills, Cash Shop, and Support sections

## Testing
- `mkdocs build` *(fails: command not found: mkdocs)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c94657d483228ad19ac524eb5eaf